### PR TITLE
Add cheatsheet class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.aux
+*.log
+*.out
+*.pdf

--- a/cheatsheet-class/main.tex
+++ b/cheatsheet-class/main.tex
@@ -1,0 +1,664 @@
+%\documentclass[landscape]{samtex-cheatsheet}
+\documentclass{samtex-cheatsheet}
+\usepackage{lipsum}
+
+\def\BibTeX{{\rm B\kern-.05em{\sc i\kern-.025em b}\kern-.08em
+    T\kern-.1667em\lower.7ex\hbox{E}\kern-.125emX}}
+
+\begin{document}
+\begin{center}
+     \Large{\textbf{\LaTeXe\ Cheat Sheet}} \\
+\end{center}
+
+\section{Document classes}
+\begin{tabular}{@{}ll@{}}
+\verb!book!    & Default is two-sided. \\
+\verb!report!  & No \verb!\part! divisions. \\
+\verb!article! & No \verb!\part! or \verb!\chapter! divisions. \\
+\verb!letter!  & Letter (?). \\
+\verb!slides!  & Large sans-serif font.
+\end{tabular}
+
+Used at the very beginning of a document:
+\verb!\documentclass{!\textit{class}\verb!}!.  Use
+\verb!\begin{document}! to start contents and \verb!\end{document}! to
+end the document.
+
+
+\subsection{Common \texttt{documentclass} options}
+\newlength{\MyLen}
+\settowidth{\MyLen}{\texttt{letterpaper}/\texttt{a4paper} \ }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\texttt{10pt}/\texttt{11pt}/\texttt{12pt} & Font size. \\
+\texttt{letterpaper}/\texttt{a4paper} & Paper size. \\
+\texttt{twocolumn} & Use two columns. \\
+\texttt{twoside}   & Set margins for two-sided. \\
+\texttt{landscape} & Landscape orientation.  Must use
+                     \texttt{dvips -t landscape}. \\
+\texttt{draft}     & Double-space lines.
+\end{tabular}
+
+Usage:
+\verb!\documentclass[!\textit{opt,opt}\verb!]{!\textit{class}\verb!}!.
+
+
+\subsection{Packages}
+\settowidth{\MyLen}{\texttt{multicol} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+%\begin{tabular}{@{}ll@{}}
+\texttt{fullpage}  &  Use 1 inch margins. \\
+\texttt{anysize}   &  Set margins: \verb!\marginsize{!\textit{l}%
+                        \verb!}{!\textit{r}\verb!}{!\textit{t}%
+                        \verb!}{!\textit{b}\verb!}!.            \\
+\texttt{multicol}  &  Use $n$ columns: 
+                        \verb!\begin{multicols}{!$n$\verb!}!.   \\
+\texttt{latexsym}  &  Use \LaTeX\ symbol font. \\
+\texttt{graphicx}  &  Show image:
+                        \verb!\includegraphics[width=!%
+                        \textit{x}\verb!]{!%
+                        \textit{file}\verb!}!. \\
+\texttt{url}       & Insert URL: \verb!\url{!%
+                        \textit{http://\ldots}%
+                        \verb!}!.
+\end{tabular}
+
+Use before \verb!\begin{document}!. 
+Usage: \verb!\usepackage{!\textit{package}\verb!}!
+
+
+\subsection{Title}
+\settowidth{\MyLen}{\texttt{.author.text.} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\author{!\textit{text}\verb!}! & Author of document. \\
+\verb!\title{!\textit{text}\verb!}!  & Title of document. \\
+\verb!\date{!\textit{text}\verb!}!   & Date. \\
+\end{tabular}
+
+These commands go before \verb!\begin{document}!.  The declaration
+\verb!\maketitle! goes at the top of the document.
+
+\subsection{Miscellaneous}
+\settowidth{\MyLen}{\texttt{.pagestyle.empty.} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\pagestyle{empty}!     &   Empty header, footer
+                                 and no page numbers. \\
+\verb!\tableofcontents!      &   Add a table of contents here. \\
+
+\end{tabular}
+
+
+
+\section{Document structure}
+\begin{multicols}{2}
+\verb!\part{!\textit{title}\verb!}!  \\
+\verb!\chapter{!\textit{title}\verb!}!  \\
+\verb!\section{!\textit{title}\verb!}!  \\
+\verb!\subsection{!\textit{title}\verb!}!  \\
+\verb!\subsubsection{!\textit{title}\verb!}!  \\
+\verb!\paragraph{!\textit{title}\verb!}!  \\
+\verb!\subparagraph{!\textit{title}\verb!}!
+\end{multicols}
+{\raggedright
+Use \verb!\setcounter{secnumdepth}{!$x$\verb!}! suppresses heading
+numbers of depth $>x$, where \verb!chapter! has depth 0.
+Use a \texttt{*}, as in \verb!\section*{!\textit{title}\verb!}!,
+to not number a particular item---these items will also not appear
+in the table of contents.
+}
+
+\subsection{Text environments}
+\settowidth{\MyLen}{\texttt{.begin.quotation.}}
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\begin{comment}!    &  Comment (not printed). Requires \texttt{verbatim} package. \\
+\verb!\begin{quote}!      &  Indented quotation block. \\
+\verb!\begin{quotation}!  &  Like \texttt{quote} with indented paragraphs. \\
+\verb!\begin{verse}!      &  Quotation block for verse.
+\end{tabular}
+
+\subsection{Lists}
+\settowidth{\MyLen}{\texttt{.begin.description.}}
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\begin{enumerate}!        &  Numbered list. \\
+\verb!\begin{itemize}!          &  Bulleted list. \\
+\verb!\begin{description}!      &  Description list. \\
+\verb!\item! \textit{text}      &  Add an item. \\
+\verb!\item[!\textit{x}\verb!]! \textit{text}
+                                &  Use \textit{x} instead of normal
+                        bullet or number.  Required for descriptions. \\
+\end{tabular}
+
+
+
+
+\subsection{References}
+\settowidth{\MyLen}{\texttt{.pageref.marker..}}
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\label{!\textit{marker}\verb!}!   &  Set a marker for cross-reference, 
+                          often of the form \verb!\label{sec:item}!. \\
+\verb!\ref{!\textit{marker}\verb!}!   &  Give section/body number of marker. \\
+\verb!\pageref{!\textit{marker}\verb!}! &  Give page number of marker. \\
+\verb!\footnote{!\textit{text}\verb!}!  &  Print footnote at bottom of page. \\
+\end{tabular}
+
+
+\subsection{Floating bodies}
+\settowidth{\MyLen}{\texttt{.begin.equation..place.}}
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\begin{table}[!\textit{place}\verb!]!     &  Add numbered table. \\
+\verb!\begin{figure}[!\textit{place}\verb!]!    &  Add numbered figure. \\
+\verb!\begin{equation}[!\textit{place}\verb!]!  &  Add numbered equation. \\
+\verb!\caption{!\textit{text}\verb!}!           &  Caption for the body. \\
+\end{tabular}
+
+The \textit{place} is a list valid placements for the body.  \texttt{t}=top,
+\texttt{h}=here, \texttt{b}=bottom, \texttt{p}=separate page, \texttt{!}=place even if ugly.  Captions and label markers should be within the environment.
+
+%---------------------------------------------------------------------------
+
+\section{Text properties}
+
+\subsection{Font face}
+\newcommand{\FontCmd}[3]{\PBS\verb!\#1{!\textit{text}\verb!}!  \> %
+                         \verb!{\#2 !\textit{text}\verb!}! \> %
+                         \#1{#3}}
+\begin{tabular}{@{}l@{}l@{}l@{}}
+\textit{Command} & \textit{Declaration} & \textit{Effect} \\
+\verb!\textrm{!\textit{text}\verb!}!                    & %
+        \verb!{\rmfamily !\textit{text}\verb!}!               & %
+        \textrm{Roman family} \\
+\verb!\textsf{!\textit{text}\verb!}!                    & %
+        \verb!{\sffamily !\textit{text}\verb!}!               & %
+        \textsf{Sans serif family} \\
+\verb!\texttt{!\textit{text}\verb!}!                    & %
+        \verb!{\ttfamily !\textit{text}\verb!}!               & %
+        \texttt{Typewriter family} \\
+\verb!\textmd{!\textit{text}\verb!}!                    & %
+        \verb!{\mdseries !\textit{text}\verb!}!               & %
+        \textmd{Medium series} \\
+\verb!\textbf{!\textit{text}\verb!}!                    & %
+        \verb!{\bfseries !\textit{text}\verb!}!               & %
+        \textbf{Bold series} \\
+\verb!\textup{!\textit{text}\verb!}!                    & %
+        \verb!{\upshape !\textit{text}\verb!}!               & %
+        \textup{Upright shape} \\
+\verb!\textit{!\textit{text}\verb!}!                    & %
+        \verb!{\itshape !\textit{text}\verb!}!               & %
+        \textit{Italic shape} \\
+\verb!\textsl{!\textit{text}\verb!}!                    & %
+        \verb!{\slshape !\textit{text}\verb!}!               & %
+        \textsl{Slanted shape} \\
+\verb!\textsc{!\textit{text}\verb!}!                    & %
+        \verb!{\scshape !\textit{text}\verb!}!               & %
+        \textsc{Small Caps shape} \\
+\verb!\emph{!\textit{text}\verb!}!                      & %
+        \verb!{\em !\textit{text}\verb!}!               & %
+        \emph{Emphasized} \\
+\verb!\textnormal{!\textit{text}\verb!}!                & %
+        \verb!{\normalfont !\textit{text}\verb!}!       & %
+        \textnormal{Document font} \\
+\verb!\underline{!\textit{text}\verb!}!                 & %
+                                                        & %
+        \underline{Underline}
+\end{tabular}
+
+The command (t\textit{tt}t) form handles spacing better than the
+declaration (t{\itshape tt}t) form.
+
+\subsection{Font size}
+\setlength{\columnsep}{14pt} % Need to move columns apart a little
+\begin{multicols}{2}
+\begin{tabbing}
+\verb!\footnotesize!          \= \kill
+\verb!\tiny!                  \>  \tiny{tiny} \\
+\verb!\scriptsize!            \>  \scriptsize{scriptsize} \\
+\verb!\footnotesize!          \>  \footnotesize{footnotesize} \\
+\verb!\small!                 \>  \small{small} \\
+\verb!\normalsize!            \>  \normalsize{normalsize} \\
+\verb!\large!                 \>  \large{large} \\
+\verb!\Large!                 \=  \Large{Large} \\  % Tab hack for new column
+\verb!\LARGE!                 \>  \LARGE{LARGE} \\
+\verb!\huge!                  \>  \huge{huge} \\
+\verb!\Huge!                  \>  \Huge{Huge}
+\end{tabbing}
+\end{multicols}
+\setlength{\columnsep}{1pt} % Set column separation back
+
+These are declarations and should be used in the form
+\verb!{\small! \ldots\verb!}!, or without braces to affect the entire
+document.
+
+
+\subsection{Verbatim text}
+
+\settowidth{\MyLen}{\texttt{.begin.verbatim..} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb@\begin{verbatim}@ & Verbatim environment. \\
+\verb@\begin{verbatim*}@ & Spaces are shown as \verb*@ @. \\
+\verb@\verb!text!@ & Text between the delimiting characters (in this case %
+                      `\texttt{!}') is verbatim.
+\end{tabular}
+
+
+\subsection{Justification}
+\begin{tabular}{@{}ll@{}}
+\textit{Environment}  &  \textit{Declaration}  \\
+\verb!\begin{center}!      & \verb!\centering!  \\
+\verb!\begin{flushleft}!  & \verb!\raggedright! \\
+\verb!\begin{flushright}! & \verb!\raggedleft!  \\
+\end{tabular}
+
+\subsection{Miscellaneous}
+\verb!\linespread{!$x$\verb!}! changes the line spacing by the
+multiplier $x$.
+
+
+
+
+
+\section{Text-mode symbols}
+
+\subsection{Symbols}
+\begin{tabular}{@{}l@{\hspace{1em}}l@{\hspace{2em}}l@{\hspace{1em}}l@{\hspace{2em}}l@{\hspace{1em}}l@{\hspace{2em}}l@{\hspace{1em}}l@{}}
+\&              &  \verb!\&! &
+\_              &  \verb!\_! &
+\ldots          &  \verb!\ldots! &
+\textbullet     &  \verb!\textbullet! \\
+\$              &  \verb!\$! &
+\^{}            &  \verb!\^{}! &
+\textbar        &  \verb!\textbar! &
+\textbackslash  &  \verb!\textbackslash! \\
+\%              &  \verb!\%! &
+\~{}            &  \verb!\~{}! &
+\#              &  \verb!\#! &
+\S              &  \verb!\S! \\
+\end{tabular}
+
+\subsection{Accents}
+\begin{tabular}{@{}l@{\ }l|l@{\ }l|l@{\ }l|l@{\ }l|l@{\ }l@{}}
+\`o   & \verb!\`o! &
+\'o   & \verb!\'o! &
+\^o   & \verb!\^o! &
+\~o   & \verb!\~o! &
+\=o   & \verb!\=o! \\
+\.o   & \verb!\.o! &
+\"o   & \verb!\"o! &
+\c o  & \verb!\c o! &
+\v o  & \verb!\v o! &
+\H o  & \verb!\H o! \\
+\c c  & \verb!\c c! &
+\d o  & \verb!\d o! &
+\b o  & \verb!\b o! &
+\t oo & \verb!\t oo! &
+\oe   & \verb!\oe! \\
+\OE   & \verb!\OE! &
+\ae   & \verb!\ae! &
+\AE   & \verb!\AE! &
+\aa   & \verb!\aa! &
+\AA   & \verb!\AA! \\
+\o    & \verb!\o! &
+\O    & \verb!\O! &
+\l    & \verb!\l! &
+\L    & \verb!\L! &
+\i    & \verb!\i! \\
+\j    & \verb!\j! &
+!`    & \verb!~`! &
+?`    & \verb!?`! &
+\end{tabular}
+
+
+\subsection{Delimiters}
+\begin{tabular}{@{}l@{\ }ll@{\ }ll@{\ }ll@{\ }ll@{\ }ll@{\ }l@{}}
+`       & \verb!`!  &
+``      & \verb!``! &
+\{      & \verb!\{! &
+\lbrack & \verb![! &
+(       & \verb!(! &
+\textless  &  \verb!\textless! \\
+'       & \verb!'!  &
+''      & \verb!''! &
+\}      & \verb!\}! &
+\rbrack & \verb!]! &
+)       & \verb!)! &
+\textgreater  &  \verb!\textgreater! \\
+\end{tabular}
+
+\subsection{Dashes}
+\begin{tabular}{@{}llll@{}}
+\textit{Name} & \textit{Source} & \textit{Example} & \textit{Usage} \\
+hyphen  & \verb!-!   & X-ray          & In words. \\
+en-dash & \verb!--!  & 1--5           & Between numbers. \\
+em-dash & \verb!---! & Yes---or no?    & Punctuation.
+\end{tabular}
+
+
+\subsection{Line and page breaks}
+\settowidth{\MyLen}{\texttt{.pagebreak} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\\!          &  Begin new line without new paragraph.  \\
+\verb!\\*!         &  Prohibit pagebreak after linebreak. \\
+\verb!\kill!       &  Don't print current line. \\
+\verb!\pagebreak!  &  Start new page. \\
+\verb!\noindent!   &  Do not indent current line.
+\end{tabular}
+
+
+\subsection{Miscellaneous}
+\settowidth{\MyLen}{\texttt{.rule.w..h.} }
+\begin{tabular}{@{}p{\the\MyLen}%
+                @{}p{\linewidth-\the\MyLen}@{}}
+\verb!\today!  &  \today. \\
+\verb!$\sim$!  &  Prints $\sim$ instead of \verb!\~{}!, which makes \~{}. \\
+\verb!~!       &  Space, disallow linebreak (\verb!W.J.~Clinton!). \\
+\verb!\@.!     &  Indicate that the \verb!.! ends a sentence when following
+                        an uppercase letter. \\
+\verb!\hspace{!$l$\verb!}! & Horizontal space of length $l$
+                                (Ex: $l=\mathtt{20pt}$). \\
+\verb!\vspace{!$l$\verb!}! & Vertical space of length $l$. \\
+\verb!\rule{!$w$\verb!}{!$h$\verb!}! & Line of width $w$ and height $h$. \\
+\end{tabular}
+
+
+
+\section{Tabular environments}
+
+\subsection{\texttt{tabbing} environment}
+\begin{tabular}{@{}l@{\hspace{1.5ex}}l@{\hspace{10ex}}l@{\hspace{1.5ex}}l@{}}
+\verb!\=!  &   Set tab stop. &
+\verb!\>!  &   Go to tab stop.
+\end{tabular}
+
+Tab stops can be set on ``invisible'' lines with \verb!\kill!
+at the end of the line.  Normally \verb!\\! is used to separate lines.
+
+
+\subsection{\texttt{tabular} environment}
+\verb!\begin{array}[!\textit{pos}\verb!]{!\textit{cols}\verb!}!   \\
+\verb!\begin{tabular}[!\textit{pos}\verb!]{!\textit{cols}\verb!}! \\
+\verb!\begin{tabular*}{!\textit{width}\verb!}[!\textit{pos}\verb!]{!\textit{cols}\verb!}!
+
+
+\subsubsection{\texttt{tabular} column specification}
+\settowidth{\MyLen}{\texttt{p}\{\textit{width}\} \ }
+\begin{tabular}{@{}p{\the\MyLen}@{}p{\linewidth-\the\MyLen}@{}}
+\texttt{l}    &   Left-justified column.  \\
+\texttt{c}    &   Centered column.  \\
+\texttt{r}    &   Right-justified column. \\
+\verb!p{!\textit{width}\verb!}!  &  Same as %
+                              \verb!\parbox[t]{!\textit{width}\verb!}!. \\ 
+\verb!@{!\textit{decl}\verb!}!   &  Insert \textit{decl} instead of
+                                    inter-column space. \\
+\verb!|!      &   Inserts a vertical line between columns. 
+\end{tabular}
+
+
+\subsubsection{\texttt{tabular} elements}
+\settowidth{\MyLen}{\texttt{.cline.x-y..}}
+\begin{tabular}{@{}p{\the\MyLen}@{}p{\linewidth-\the\MyLen}@{}}
+\verb!\hline!           &  Horizontal line between rows.  \\
+\verb!\cline{!$x$\verb!-!$y$\verb!}!  &
+                        Horizontal line across columns $x$ through $y$. \\
+\verb!\multicolumn{!\textit{n}\verb!}{!\textit{cols}\verb!}{!\textit{text}\verb!}! \\
+        &  A cell that spans \textit{n} columns, with \textit{cols} column specification.
+\end{tabular}
+
+\section{Math mode}
+For inline math, use \verb!\(...\)! or \verb!$...$!.
+For displayed math, use \verb!\[...\]! or \verb!\begin{equation}!.
+
+\begin{tabular}{@{}l@{\hspace{1em}}l@{\hspace{2em}}l@{\hspace{1em}}l@{}}
+Superscript$^{x}$       &
+\verb!^{x}!             &  
+Subscript$_{x}$         &
+\verb!_{x}!             \\  
+$\frac{x}{y}$           &
+\verb!\frac{x}{y}!      &  
+$\sum_{k=1}^n$          &
+\verb!\sum_{k=1}^n!     \\  
+$\sqrt[n]{x}$           &
+\verb!\sqrt[n]{x}!      &  
+$\prod_{k=1}^n$         &
+\verb!\prod_{k=1}^n!    \\ 
+\end{tabular}
+
+\subsection{Math-mode symbols}
+
+% The ordering of these symbols is slightly odd.  This is because I had to put all the
+% long pieces of text in the same column (the right) for it all to fit properly.
+% Otherwise, it wouldn't be possible to fit four columns of symbols here.
+
+\begin{tabular}{@{}l@{\hspace{1ex}}l@{\hspace{1em}}l@{\hspace{1ex}}l@{\hspace{1em}}l@{\hspace{1ex}} l@{\hspace{1em}}l@{\hspace{1ex}}l@{}}
+$\leq$          &  \verb!\leq!  &
+$\geq$          &  \verb!\geq!  &
+$\neq$          &  \verb!\neq!  &
+$\approx$       &  \verb!\approx!  \\
+$\times$        &  \verb!\times!  &
+$\div$          &  \verb!\div!  &
+$\pm$           & \verb!\pm!  &
+$\cdot$         &  \verb!\cdot!  \\
+$^{\circ}$      & \verb!^{\circ}! &
+$\circ$         &  \verb!\circ!  &
+$\prime$        & \verb!\prime!  &
+$\cdots$        &  \verb!\cdots!  \\
+$\infty$        & \verb!\infty!  &
+$\neg$          & \verb!\neg!  &
+$\wedge$        & \verb!\wedge!  &
+$\vee$          & \verb!\vee!  \\
+$\supset$       & \verb!\supset!  &
+$\forall$       & \verb!\forall!  &
+$\in$           & \verb!\in!  &
+$\rightarrow$   &  \verb!\rightarrow! \\
+$\subset$       & \verb!\subset!  &
+$\exists$       & \verb!\exists!  &
+$\notin$        & \verb!\notin!  &
+$\Rightarrow$   &  \verb!\Rightarrow! \\
+$\cup$          & \verb!\cup!  &
+$\cap$          & \verb!\cap!  &
+$\mid$          & \verb!\mid!  &
+$\Leftrightarrow$   &  \verb!\Leftrightarrow! \\
+$\dot a$        & \verb!\dot a!  &
+$\hat a$        & \verb!\hat a!  &
+$\bar a$        & \verb!\bar a!  &
+$\tilde a$      & \verb!\tilde a!  \\
+
+$\alpha$        &  \verb!\alpha!  &
+$\beta$         &  \verb!\beta!  &
+$\gamma$        &  \verb!\gamma!  &
+$\delta$        &  \verb!\delta!  \\
+$\epsilon$      &  \verb!\epsilon!  &
+$\zeta$         &  \verb!\zeta!  &
+$\eta$          &  \verb!\eta!  &
+$\varepsilon$   &  \verb!\varepsilon!  \\
+$\theta$        &  \verb!\theta!  &
+$\iota$         &  \verb!\iota!  &
+$\kappa$        &  \verb!\kappa!  &
+$\vartheta$     &  \verb!\vartheta!  \\
+$\lambda$       &  \verb!\lambda!  &
+$\mu$           &  \verb!\mu!  &
+$\nu$           &  \verb!\nu!  &
+$\xi$           &  \verb!\xi!  \\
+$\pi$           &  \verb!\pi!  &
+$\rho$          &  \verb!\rho!  &
+$\sigma$        &  \verb!\sigma!  &
+$\tau$          &  \verb!\tau!  \\
+$\upsilon$      &  \verb!\upsilon!  &
+$\phi$          &  \verb!\phi!  &
+$\chi$          &  \verb!\chi!  &
+$\psi$          &  \verb!\psi!  \\
+$\omega$        &  \verb!\omega!  &
+$\Gamma$        &  \verb!\Gamma!  &
+$\Delta$        &  \verb!\Delta!  &
+$\Theta$        &  \verb!\Theta!  \\
+$\Lambda$       &  \verb!\Lambda!  &
+$\Xi$           &  \verb!\Xi!  &
+$\Pi$           &  \verb!\Pi!  &
+$\Sigma$        &  \verb!\Sigma!  \\
+$\Upsilon$      &  \verb!\Upsilon!  &
+$\Phi$          &  \verb!\Phi!  &
+$\Psi$          &  \verb!\Psi!  &
+$\Omega$        &  \verb!\Omega!  
+\end{tabular}
+\footnotesize
+
+%\subsection{Special symbols}
+%\begin{tabular}{@{}ll@{}}
+%$^{\circ}$  &  \verb!^{\circ}! Ex: $22^{\circ}\mathrm{C}$: \verb!$22^{\circ}\mathrm{C}$!.
+%\end{tabular}
+
+\section{Bibliography and citations}
+When using \BibTeX, you need to run \texttt{latex}, \texttt{bibtex},
+and \texttt{latex} twice more to resolve dependencies.
+
+\subsection{Citation types}
+\settowidth{\MyLen}{\texttt{.shortciteN.key..}}
+\begin{tabular}{@{}p{\the\MyLen}@{}p{\linewidth-\the\MyLen}@{}}
+\verb!\cite{!\textit{key}\verb!}!       &
+        Full author list and year. (Watson and Crick 1953) \\
+\verb!\citeA{!\textit{key}\verb!}!      &
+        Full author list. (Watson and Crick) \\
+\verb!\citeN{!\textit{key}\verb!}!      &
+        Full author list and year. Watson and Crick (1953) \\
+\verb!\shortcite{!\textit{key}\verb!}!  &
+        Abbreviated author list and year. ? \\
+\verb!\shortciteA{!\textit{key}\verb!}! &
+        Abbreviated author list. ? \\
+\verb!\shortciteN{!\textit{key}\verb!}! &
+        Abbreviated author list and year. ? \\
+\verb!\citeyear{!\textit{key}\verb!}!   &
+        Cite year only. (1953) \\
+\end{tabular}
+
+All the above have an \texttt{NP} variant without parentheses;
+Ex. \verb!\citeNP!.
+
+
+\subsection{\BibTeX\ entry types}
+\settowidth{\MyLen}{\texttt{.mastersthesis.}}
+\begin{tabular}{@{}p{\the\MyLen}@{}p{\linewidth-\the\MyLen}@{}}
+\verb!@article!         &  Journal or magazine article. \\
+\verb!@book!            &  Book with publisher. \\
+\verb!@booklet!         &  Book without publisher. \\
+\verb!@conference!      &  Article in conference proceedings. \\
+\verb!@inbook!          &  A part of a book and/or range of pages. \\
+\verb!@incollection!    &  A part of book with its own title. \\
+%\verb!@manual!          &  Technical documentation. \\
+%\verb!@mastersthesis!   &  Master's thesis. \\
+\verb!@misc!            &  If nothing else fits. \\
+\verb!@phdthesis!       &  PhD. thesis. \\
+\verb!@proceedings!     &  Proceedings of a conference. \\
+\verb!@techreport!      &  Tech report, usually numbered in series. \\
+\verb!@unpublished!     &  Unpublished. \\
+\end{tabular}
+
+\subsection{\BibTeX\ fields}
+\settowidth{\MyLen}{\texttt{organization.}}
+\begin{tabular}{@{}p{\the\MyLen}@{}p{\linewidth-\the\MyLen}@{}}
+\verb!address!         &  Address of publisher.  Not necessary for major
+                                publishers.  \\
+\verb!author!           &  Names of authors, of format .... \\
+\verb!booktitle!        &  Title of book when part of it is cited. \\
+\verb!chapter!          &  Chapter or section number. \\
+\verb!edition!          &  Edition of a book. \\
+\verb!editor!           &  Names of editors. \\
+\verb!institution!      &  Sponsoring institution of tech.\ report. \\
+\verb!journal!          &  Journal name. \\
+\verb!key!              &  Used for cross ref.\ when no author. \\
+\verb!month!            &  Month published. Use 3-letter abbreviation. \\
+\verb!note!             &  Any additional information. \\
+\verb!number!           &  Number of journal or magazine. \\
+\verb!organization!     &  Organization that sponsors a conference. \\
+\verb!pages!            &  Page range (\verb!2,6,9--12!). \\
+\verb!publisher!        &  Publisher's name. \\
+\verb!school!           &  Name of school (for thesis). \\
+\verb!series!           &  Name of series of books. \\
+\verb!title!            &  Title of work. \\
+\verb!type!             &  Type of tech.\ report, ex. ``Research Note''. \\
+\verb!volume!           &  Volume of a journal or book. \\
+\verb!year!             &  Year of publication. \\
+\end{tabular}
+Not all fields need to be filled.  See example below.
+
+\subsection{Common \BibTeX\ style files}
+\begin{tabular}{@{}l@{\hspace{1em}}l@{\hspace{3em}}l@{\hspace{1em}}l@{}}
+\verb!abbrv!    &  Standard &
+\verb!abstract! &  \texttt{alpha} with abstract \\
+\verb!alpha!    &  Standard &
+\verb!apa!      &  APA \\
+\verb!plain!    &  Standard &
+\verb!unsrt!    &  Unsorted \\
+\end{tabular}
+
+The \LaTeX\ document should have the following two lines just before
+\verb!\end{document}!, where \verb!bibfile.bib! is the name of the
+\BibTeX\ file.
+\begin{verbatim}
+\bibliographystyle{plain}
+\bibliography{bibfile}
+\end{verbatim}
+
+\subsection{\BibTeX\ example}
+The \BibTeX\ database goes in a file called
+\textit{file}\texttt{.bib}, which is processed with \verb!bibtex file!. 
+\begin{verbatim}
+@String{N = {Na\-ture}}
+@Article{WC:1953,
+  author  = {James Watson and Francis Crick},
+  title   = {A structure for Deoxyribose Nucleic Acid},
+  journal = N,
+  volume  = {171},
+  pages   = {737},
+  year    = 1953
+}
+\end{verbatim}
+
+
+\section{Sample \LaTeX\ document}
+\begin{verbatim}
+\documentclass[11pt]{article}
+\usepackage{fullpage}
+\title{Template}
+\author{Name}
+\begin{document}
+\maketitle
+
+\section{section}
+\subsection*{subsection without number}
+text \textbf{bold text} text. Some math: $2+2=5$
+\subsection{subsection}
+text \emph{emphasized text} text. \cite{WC:1953}
+discovered the structure of DNA.
+
+A table:
+\begin{table}[!th]
+\begin{tabular}{|l|c|r|}
+\hline
+first  &  row  &  data \\
+second &  row  &  data \\
+\hline
+\end{tabular}
+\caption{This is the caption}
+\label{ex:table}
+\end{table}
+
+The table is numbered \ref{ex:table}.
+\end{document}
+\end{verbatim}
+
+
+
+\rule{0.3\linewidth}{0.25pt}
+\scriptsize
+
+Copyright \copyright\ 2014 Winston Chang
+
+\href{http://wch.github.io/latexsheet/}{http://wch.github.io/latexsheet/}
+\end{document}

--- a/cheatsheet-class/samtex-cheatsheet.cls
+++ b/cheatsheet-class/samtex-cheatsheet.cls
@@ -1,0 +1,59 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{samtex-cheatsheet}[2022/10/15 A cheatsheet class based off of http://wch.github.io/latexsheet/]
+
+\LoadClass[10pt,landscape]{article}
+\RequirePackage{multicol}
+\RequirePackage{calc}
+\RequirePackage{ifthen}
+\RequirePackage[landscape]{geometry}
+\RequirePackage{hyperref}
+
+\ifthenelse{\lengthtest { \paperwidth = 11in}}
+	{ \geometry{top=.5in,left=.5in,right=.5in,bottom=.5in} }
+	{\ifthenelse{ \lengthtest{ \paperwidth = 297mm}}
+		{\geometry{top=1cm,left=1cm,right=1cm,bottom=1cm} }
+		{\geometry{top=1cm,left=1cm,right=1cm,bottom=1cm} }
+	}
+
+% Turn off header and footer
+\pagestyle{empty}
+ 
+
+% Redefine section commands to use less space
+\renewcommand{\section}{\@startsection{section}{1}{0mm}%
+                                {-1ex plus -.5ex minus -.2ex}%
+                                {0.5ex plus .2ex}%x
+                                {\normalfont\large\bfseries}}
+\renewcommand{\subsection}{\@startsection{subsection}{2}{0mm}%
+                                {-1explus -.5ex minus -.2ex}%
+                                {0.5ex plus .2ex}%
+                                {\normalfont\normalsize\bfseries}}
+\renewcommand{\subsubsection}{\@startsection{subsubsection}{3}{0mm}%
+                                {-1ex plus -.5ex minus -.2ex}%
+                                {1ex plus .2ex}%
+                                {\normalfont\small\bfseries}}
+
+% Don't print section numbers
+\setcounter{secnumdepth}{0}
+
+
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{0pt plus 0.5ex}
+
+\AtBeginDocument{
+    \raggedright
+    \footnotesize
+    \begin{multicols}{3}
+
+
+    % multicol parameters
+    % These lengths are set only within the two main columns
+    %\setlength{\columnseprule}{0.25pt}
+    \setlength{\premulticols}{1pt}
+    \setlength{\postmulticols}{1pt}
+    \setlength{\multicolsep}{1pt}
+    \setlength{\columnsep}{2pt}
+}
+\AtEndDocument{
+    \end{multicols}
+}

--- a/cheatsheet-class/samtex-cheatsheet.cls
+++ b/cheatsheet-class/samtex-cheatsheet.cls
@@ -1,3 +1,4 @@
+% vim: set filetype=tex
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{samtex-cheatsheet}[2022/10/15 A cheatsheet class based off of http://wch.github.io/latexsheet/]
 

--- a/cheatsheet-class/samtex-cheatsheet.cls
+++ b/cheatsheet-class/samtex-cheatsheet.cls
@@ -5,7 +5,7 @@
 \RequirePackage{multicol}
 \RequirePackage{calc}
 \RequirePackage{ifthen}
-\RequirePackage[landscape]{geometry}
+\RequirePackage{geometry}
 \RequirePackage{hyperref}
 
 \ifthenelse{\lengthtest { \paperwidth = 11in}}


### PR DESCRIPTION
Theoretically, this will allow you to write `\documentclass{samtex-cheatsheet}` and get a nice, multi-column, landscape cheat sheet. Obviously, there are more configuration options that should be added, but the larger problem is that the class doesn't work as is.

Right now, you need to pass the `[landscape]` option, as in the commented-out first line of `main.tex`. Hopefully I will figure out why this is necessary and how to eliminate this requirement. Waiting on: https://tex.stackexchange.com/questions/661831/creating-a-latex-package-that-forces-landscape-mode